### PR TITLE
Fixing the tab width error. 

### DIFF
--- a/src/main/java/org/dockfx/pane/ContentTabPane.java
+++ b/src/main/java/org/dockfx/pane/ContentTabPane.java
@@ -4,11 +4,15 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Stack;
 import java.util.stream.Collectors;
+
+import javafx.collections.ListChangeListener;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.control.Skin;
+import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
 
+import javafx.scene.control.Tooltip;
 import org.dockfx.DockNode;
 import org.dockfx.DockPos;
 import org.dockfx.pane.skin.ContentTabPaneSkin;
@@ -25,8 +29,20 @@ public class ContentTabPane extends TabPane implements ContentPane
 
   public ContentTabPane()
   {
+    getTabs().addListener((ListChangeListener<? super Tab>)  observable -> {
+      updateTabWidth();
+    });
+    widthProperty().addListener((obs, oldVal, newVal) -> {
+      updateTabWidth();
+    });
   }
-
+  private void updateTabWidth(){
+    if(getTabs().size()<1)
+      return;
+    double w = (getWidth()-100)/((double)getTabs().size());
+    setTabMaxWidth(w);
+    setTabMinWidth(w);
+  }
   /** {@inheritDoc} */
   @Override
   protected Skin<?> createDefaultSkin()
@@ -127,6 +143,7 @@ public class ContentTabPane extends TabPane implements ContentPane
 
   public void addDockNodeTab(DockNodeTab dockNodeTab)
   {
+    dockNodeTab.setTooltip(new Tooltip(dockNodeTab.getTitle()));
     getTabs().add(dockNodeTab);
     getSelectionModel().select(dockNodeTab);
   }


### PR DESCRIPTION
In the Java11 implementation there is an error with the off-screen tabs button. The button which opens a menu of all the tabs in the pain lets you select off screen buttons. In Java11 this menu comes up with blank names. 

The solution is to make the tabs auto size so they never fall off the screen. A tooltip is added to read the titles of tabs that are too small to read. 